### PR TITLE
Closes issue #24, Wrong Email/Password

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -304,6 +304,20 @@ void BarSettingsRead (BarSettings_t *settings) {
 				*valend = '\0';
 				--valend;
 			}
+			
+			/* fix errors with leading/trailing space on user/password fields */
+			if (streq("user", key) || streq("password", key)) {
+				/* trim leading space */
+				while (isspace((unsigned char)*val)) val++;
+
+				/* trim trailing space */
+				char* end;
+				end = val + strlen(val) - 1;
+				while (end > val && isspace((unsigned char)*end)) end--;
+				
+				/* write new null terminator */
+				end[1] = '\0';
+			}			
 
 			if (streq ("control_proxy", key)) {
 				settings->controlProxy = strdup (val);


### PR DESCRIPTION
This fix trims leading/trailing whitespace from the user/password fields in the config, solving issues with users getting login errors when there is excess whitespace.