### PR TITLE
Implemented eventcmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Older releases can be found at [GitHub Release page](https://github.com/thedmd/p
 * Configure keybindings.
 * last.fm scrobbling support (external application)
 * Proxy support for listeners outside the USA.
+* Execute eventcmd to script notification for song being played
 
 ### Source Code
 

--- a/pianobar.cfg.example
+++ b/pianobar.cfg.example
@@ -104,4 +104,4 @@ subscribed_events = songstart,songfinish
 
 # you can pass variable substitution to event_command to get the current songs.
 # Variables supported: $artist, $album, $song, and $station
-event_command = C:\Users\Jonathan\bin\wsl-notify-send.exe --appId "Pianobar" --category "$station" "$artist `n$album `n$song"
+event_command = C:\Users\Jonathan\bin\wsl-notify-send.exe --appId "Pianobar" --category "$station" "$artist `n$album `n$song" -i "$coverArt"

--- a/pianobar.cfg.example
+++ b/pianobar.cfg.example
@@ -90,3 +90,18 @@ format_msg_debug = [90m%s[0m
 # Example bindings:
 #hk_act_songpausetoggle = media_play_pause
 #hk_act_songnext = media_next_track
+
+
+# events that should fire the event_command (comma separated);
+# current possible events are:
+# userlogin,usergetstations,stationfetchplaylist,songstart,songfinish
+#
+# note, only songstart and songfinish have all the variable substitution support, other events are not well-tested
+#
+# example usage: 
+# subscribed_events = songstart,songfinish
+subscribed_events = songstart,songfinish
+
+# you can pass variable substitution to event_command to get the current songs.
+# Variables supported: $artist, $album, $song, and $station
+event_command = C:\Users\Jonathan\bin\wsl-notify-send.exe --appId "Pianobar" --category "$station" "$artist `n$album `n$song"

--- a/src/config.h
+++ b/src/config.h
@@ -3,9 +3,10 @@
 /* package name */
 #define PACKAGE "pianobar"
 
-#define VERSION "2022.10.09-dev"
+#define VERSION "2024.07.04-dev"
 
 #define TITLE   "Pianobar"
+
 
 /* Visual C++ name restrict differently */
 #ifdef _WIN32

--- a/src/console.h
+++ b/src/console.h
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "config.h"
 #include <stdio.h>
 #include <stdarg.h>
-#include <windows.h>
+#include <Windows.h>
 
 void BarConsoleInit ();
 void BarConsoleDestroy ();

--- a/src/main.c
+++ b/src/main.c
@@ -305,8 +305,11 @@ static void BarMainStartPlayback(BarApp_t *app)
  */
 static void BarMainPlayerCleanup(BarApp_t *app)
 {
-    BarUiStartEventCmd(&app->settings, "songfinish", app->curStation,
-        app->playlist, &app->player, app->ph.stations, PIANO_RET_OK);
+    // without this, pianobar starts main loop firing an empty songfinish; let's avoid that
+    if (app->playlist != NULL) {
+        BarUiStartEventCmd(&app->settings, "songfinish", app->curStation,
+            app->playlist, &app->player, app->ph.stations, PIANO_RET_OK);
+    }
 
     BarPlayer2Finish(app->player);
 

--- a/src/main.c
+++ b/src/main.c
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include <piano.h>
 
 #include "main.h"
-#include "debug.h"
+//#include "debug.h"
 #include "console.h"
 #include "hotkey.h"
 #include "ui.h"
@@ -424,7 +424,7 @@ int main(int argc, char **argv)
 {
     static BarApp_t app;
 
-	debugEnable();
+	//debugEnable();
 
     memset(&app, 0, sizeof(app));
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -143,6 +143,7 @@ void BarSettingsDestroy (BarSettings_t *settings) {
 	free (settings->password);
 	free (settings->passwordCmd);
 	free (settings->autostartStation);
+	free (settings->subscribedEvents);
 	free (settings->eventCmd);
 	free (settings->loveIcon);
 	free (settings->banIcon);
@@ -381,9 +382,12 @@ void BarSettingsRead (BarSettings_t *settings) {
 				} else if (streq (val, "high")) {
 					settings->audioQuality = PIANO_AQ_HIGH;
 				}
-			} else if (streq ("autostart_station", key)) {
-				free (settings->autostartStation);
-				settings->autostartStation = strdup (val);
+			} else if (streq("autostart_station", key)) {
+				free(settings->autostartStation);
+				settings->autostartStation = strdup(val);
+			} else if (streq("subscribed_events", key)) {
+				free(settings->subscribedEvents);
+				settings->subscribedEvents = strdup(val);
 			} else if (streq ("event_command", key)) {
 				settings->eventCmd = BarSettingsExpandTilde (val, userhome);
 			} else if (streq ("history", key)) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -97,6 +97,7 @@ typedef struct {
 	char *proxy;
 	char *bindTo;
 	char *autostartStation;
+	char *subscribedEvents;
 	char *eventCmd;
 	char *loveIcon, *banIcon, *tiredIcon;
 	char *atIcon;

--- a/src/ui.c
+++ b/src/ui.c
@@ -778,6 +778,11 @@ void BarUiStartEventCmd (const BarSettings_t *settings, const char *type,
 		return;
 	}
 
+	if (settings->subscribedEvents == NULL) {
+		/* no subscribed events... */
+		return;
+	}
+
 	char* subscribedEvents = strdup(settings->subscribedEvents);
 	int subscribed = 0;
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -810,22 +810,32 @@ void BarUiStartEventCmd (const BarSettings_t *settings, const char *type,
 	char* replacement1 = NULL;
 	char* replacement2 = NULL;
 	char* replacement3 = NULL;
+	char* replacement4 = NULL;
 	char* cmd = NULL;
 
 	replacement1 = replaceWord(settings->eventCmd, "$song", curSong == NULL ? "" : curSong->title);
 	replacement2 = replaceWord(replacement1, "$artist", curSong == NULL ? "" : curSong->artist);
 	replacement3 = replaceWord(replacement2, "$album", curSong == NULL ? "" : curSong->album);
-	cmd = replaceWord(replacement3, "$station", curStation == NULL ? "" : curStation->name);
+	replacement4 = replaceWord(replacement3, "$coverArt", curSong == NULL ? "" : curSong->coverArt);
+	cmd = replaceWord(replacement4, "$station", curStation == NULL ? "" : curStation->name);
 	free(replacement1);
 	free(replacement2);
 	free(replacement3);
+	free(replacement4);
 
 	BarUiMsg(settings, MSG_DEBUG, "Raw command to run: %s\n", cmd);
 
 	wchar_t wcmd[10000];
 	mbstowcs(wcmd, cmd, 10000);
 
-
+	BarUiMsg(settings, MSG_DEBUG, 
+		"Variables:\nartist=%s\nalbum=%s\ntitle=%s\ncoverArt=%s\nstationName=%s\n",
+		curSong == NULL ? "" : curSong->artist,
+		curSong == NULL ? "" : curSong->album,
+		curSong == NULL ? "" : curSong->title, 
+		curSong == NULL ? "" : curSong->coverArt,
+		curStation == NULL ? "" : curStation->name
+	);
 
 	STARTUPINFO si;
 	PROCESS_INFORMATION pi;


### PR DESCRIPTION
Implemented eventcmd functionality. Please note new configuration options:

```
# events that should fire the event_command (comma separated);
# current possible events are:
# userlogin,usergetstations,stationfetchplaylist,songstart,songfinish
#
# example usage: 
# subscribed_events = songstart,songfinish
subscribed_events = songstart,songfinish

# you can pass variable substitution to event_command to replace variable with the actual item.
# Variables supported: $artist, $album, $song, and $station
event_command = C:\Users\Jonathan\bin\wsl-notify-send.exe --appId "Pianobar" --category "$station" "$artist `n$album `n$song"
```

Please also note, I am NOT a regular C/C++ developer. I haven't touched C since I was in school over 10 years ago. The code in here is very hacky and may need a rewrite. This should be at least a good starting point to implement this. I did test this and it works with making a popup notification toaster like I wanted with the `wsl-notify-send` application.


![image](https://github.com/thedmd/pianobar-windows/assets/1827190/11595835-0e34-4643-a83a-1dd549135966)

